### PR TITLE
First version - Added MongoDB Logging to WPWithin

### DIFF
--- a/sdkcore/examples/sample-producer-callbacks/main.go
+++ b/sdkcore/examples/sample-producer-callbacks/main.go
@@ -61,7 +61,7 @@ func addService() {
 	roboWash, _ := types.NewService()
 	roboWash.Name = "RoboWash"
 	roboWash.Description = "Car washed by robot"
-	roboWash.Id = 1
+	roboWash.ID = 1
 
 	washPriceCar := types.Price{
 

--- a/sdkcore/wpwithin/core/core.go
+++ b/sdkcore/wpwithin/core/core.go
@@ -7,6 +7,7 @@ import (
 	"github.com/wptechinnovation/worldpay-within-sdk/sdkcore/wpwithin/servicediscovery"
 	"github.com/wptechinnovation/worldpay-within-sdk/sdkcore/wpwithin/types"
 	"github.com/wptechinnovation/worldpay-within-sdk/sdkcore/wpwithin/types/event"
+	"github.com/wptechinnovation/worldpay-within-sdk/sdkcore/wpwithin/mongodblogger" //MongoDB Diff
 )
 
 // Core This acts as a container for dependencies of the SDK
@@ -21,12 +22,14 @@ type Core struct {
 	HTEClient      hte.Client
 	EventHandler   event.Handler
 	Configuration  configuration.WPWithin
+	Logger         *mongodblogger.MongoDBLogger // MongoDB Diff
 }
 
 // NewCore Create a new Core
 func NewCore() (*Core, error) {
 
 	result := &Core{}
+	result.Logger = new( mongodblogger.MongoDBLogger )
 
 	return result, nil
 }

--- a/sdkcore/wpwithin/mongodblogger/mongodblogger.go
+++ b/sdkcore/wpwithin/mongodblogger/mongodblogger.go
@@ -1,0 +1,183 @@
+package mongodblogger
+
+import (
+	"os"
+	"time"
+	"gopkg.in/mgo.v2"
+)
+
+//
+// Joe.Drumgoole@mongodb.com
+//
+// A Simple logging package for WPWWithin Framework
+//
+
+// must point at a running writeable MongoDB Server
+const WPW_MONGODB_SERVER   string = "WPW_MONGODB_SERVER"
+
+// Set to anything to turn logging on
+const WPW_MONGODB_LOGGING  string = "WPW_MONGODB_LOGGING" 
+
+const WPW_EVENT_DATABASE   string = "WPWEvents" 
+
+const WPW_EVENT_COLLECTION string = "WPWLog" 
+
+
+type MongoDBLogger struct {
+	
+	MgoSession  *mgo.Session
+	DB          *mgo.Database
+	Collection  *mgo.Collection
+	loggingOn   bool
+	
+}
+
+type StringEvent struct {
+
+	Name             string
+	Msg              string
+	Timestamp        time.Time
+}
+
+type IntEvent struct {
+
+	Name             string
+	Msg              string
+	Amount			 int64
+	Timestamp        time.Time
+}
+
+type FloatEvent struct {
+
+	Name             string
+	Msg              string
+	Amount			 float64
+	Timestamp        time.Time
+}
+
+type PaymentEvent struct {
+
+	Name             string
+	Msg              string
+	Payment		     interface{}
+	Timestamp        time.Time
+}
+
+type DocEvent struct {
+
+	Name             string
+	Msg              string
+	Doc 		     interface{}
+	Timestamp        time.Time
+}
+func ( m *MongoDBLogger ) Initialise() error {
+	
+	m.loggingOn = true
+	
+	serverUrl := os.Getenv( WPW_MONGODB_SERVER ) 
+	if serverUrl == "" {
+		m.TurnLoggingOff()
+	} else {
+
+		session, err := mgo.Dial( serverUrl )
+		
+		if err != nil {
+			return err
+		} else {
+			m.MgoSession = session
+		}
+		
+		m.DB         = m.MgoSession.DB( WPW_EVENT_DATABASE )
+		m.Collection = m.DB.C( WPW_EVENT_COLLECTION )
+	
+	}	
+	
+	loggingOn := os.Getenv( WPW_MONGODB_LOGGING ) 
+	
+	if ( loggingOn == "ON" ) && ( serverUrl != "" ){
+		m.TurnLoggingOn()
+	} else {
+		m.TurnLoggingOff()
+	}
+	
+	return nil
+}
+
+func ( m *MongoDBLogger ) TurnLoggingOn() bool {
+	m.loggingOn = true
+	return m.loggingOn
+	
+}
+
+func ( m *MongoDBLogger )  TurnLoggingOff() bool {
+	m.loggingOn = false
+	return m.loggingOn
+	
+}
+
+func ( m *MongoDBLogger ) LogEventStr( name string, message string ) error {
+	
+	if m.loggingOn {
+		
+		err := m.Collection.Insert( &StringEvent{ Name      : name, 
+										          Msg       : message, 
+										          Timestamp : time.Now()})
+		return err
+	}
+	return nil
+}
+
+func ( m *MongoDBLogger ) LogEventInt( name string, message string, amount int64 ) error {
+	
+	if m.loggingOn {
+		
+		err := m.Collection.Insert( &IntEvent{ Name      : name, 
+										       Msg       : message,
+										       Amount    : amount,
+										       Timestamp : time.Now()})
+		return err
+	}
+	return nil
+}
+
+func ( m *MongoDBLogger ) LogEventFloat( name string, message string, amount float64) error {
+	
+	if m.loggingOn {
+		
+		err := m.Collection.Insert( &FloatEvent{ Name      : name, 
+										         Msg       : message, 
+										         Amount    : amount,
+										         Timestamp : time.Now()})
+
+		return err
+	}
+	return nil
+}
+
+func ( m *MongoDBLogger ) LogEventDoc( name string, message string, doc interface{}) error {
+	
+	if m.loggingOn {
+	
+		err := m.Collection.Insert( &DocEvent{ Name      : name, 
+										       Msg       : message, 
+										       Doc       : doc,
+										       Timestamp : time.Now()})
+
+		return err
+	}
+	return nil
+}
+
+func ( m *MongoDBLogger ) LogEventPayment( name string, message string, payment interface{}) error {
+	
+	if m.loggingOn {
+	
+		err := m.Collection.Insert( &PaymentEvent{ Name      : name, 
+										           Msg       : message, 
+										           Payment   : payment,
+										           Timestamp : time.Now()})
+
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
Added a new MongoDB Logger object to core.go
Added a new package mongodblogger containing all the mongodb specific code.
Updated wpwithin.go to instrument all API calls.

To turn on logging set environment variable WPW_MONGODB_LOGGING=ON

You must also point WPW_MONGODB_SERVER to a valid MongoDB server (e.g. localhost). 

If either of these are not set logging becomes a noop.

Also fixed a bug in sample-producer-callbacks/main.go.

You will need the Mgo MongoDB Driver library.
go get gopkg.in/mgo.v2

